### PR TITLE
Add missing GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with Git and GitHub",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Add the missing **GitHub Skills** activity to the activities catalog so students can register for it.

## Changes
- Added a new `GitHub Skills` entry to the `activities` dictionary in `src/app.py`
- Included description, schedule, participant capacity, and initial participant list

## Validation
- `python3 -m py_compile src/app.py`

Closes #6